### PR TITLE
Added error handling for peek function

### DIFF
--- a/src/xyz/jadonfowler/o/O.java
+++ b/src/xyz/jadonfowler/o/O.java
@@ -1122,6 +1122,7 @@ class Stack {
     }
 
     public Object peek() {
+        if (i <= -1) throw new ArrayIndexOutOfBoundsException("Can't peek into and empty stack!");
         return stack[i];
     }
 


### PR DESCRIPTION
`.o` just returns `-1` as an error as is.
Added code so it throws an `ArrayIndexOutOfBoundsException` for a more useful error.