### PR TITLE
Dicitonaries!!! :D

### DIFF
--- a/o.c
+++ b/o.c
@@ -76,7 +76,7 @@ S tos(O o){
     case TS:r=alc(o->s.z+1);memcpy(r,o->s.s,o->s.z);r[o->s.z]=0;BK;
     case TA:r=alc(1);r[0]='[';z=1;for(i=0;i<len(o->a);++i){L l;if(i){r=rlc(r,z+1);r[z++]=',';}t=tos(o->a->st[i]);l=strlen(t);r=rlc(r,z+l);memcpy(r+z,t,l);z+=l;DL(t);}r=rlc(r,z+2);r[z]=']';r[z+1]=0;BK;
     case TCB:r=alc(o->s.z+3);r[0]='{';memcpy(r+1,o->s.s,o->s.z);memcpy(r+1+o->s.z,"}",2);BK;
-    case TR:{L lv;S tv;t=tos(o->e.k);tv=tos(o->e.v);z=strlen(t);lv=strlen(tv);r=alc(z+lv+5);sprintf(r,"{%s: %s}",t,tv);}BK;
+    case TR:{L lv;S tv;t=tos(o->e.k);tv=tos(o->e.v);z=strlen(t);lv=strlen(tv);r=alc(z+lv+5);sprintf(r,"{%s: %s}",t,tv);DL(t);DL(tv);}BK;
     }R r;
 } //tostring (copies)
 O newo(){R alc(sizeof(OB));} //new object

--- a/o.c
+++ b/o.c
@@ -68,7 +68,7 @@ ST rst=0; //root stack
 typedef enum{TD,TS,TA,TCB,TR}OT; //decimal,string,array,codeblock,entry
 #define TN (TR+1) //# of types
 typedef struct OB OB;typedef OB* O;
-struct OB{OT t;union{F d;struct{S s;L z;}s;ST a;struct{O k,v;} e;};};typedef OB*O; //type:type flag,value{decimal,{string,len},array,entry}(NOTE:code blocks use string struct to store their code!)
+struct OB{OT t;union{F d;struct{S s;L z;}s;ST a;struct{O k,v;}e;};};typedef OB*O; //type:type flag,value{decimal,{string,len},array,entry}(NOTE:code blocks use string struct to store their code!)
 V excb(O);
 S tos(O o){
     S r,t;L z,i;switch(o->t){
@@ -275,6 +275,7 @@ V uv(ST s,O o){if(o->t==TCB)excb(o);else psh(s,dup(o));} //execute the object if
 V bcv(ST s){ST r;I i=0,a,b;O ao,bo=pop(s);ao=pop(s);if(ao->t!=TD||bo->t!=TD)TE;a=ao->d;b=bo->d/*truncate*/;dlo(ao);dlo(bo);r=newst(BZ);while(a){C c=a%b+'0';if(c>'9')c+=7;psh(r,newod(a%b));if(b==1)--a;else a/=b;}psh(s,newoa(r));} //base conversion
 
 V entry(ST s){O k,v=pop(s);k=pop(s);psh(s,newoe(k,v));}
+O idx(ST s){O a,k=pop(s);a=pop(s);I i;if(a->t!=TA)TE;for(i=0;i<len(a->a);++i){O e=a->a->st[i];if(e->t!=TR)TE;if(eqo(e->e.k,k)){O v=dup(e->e.v);dlo(a);dlo(k);R v;};}ex("nonexistent key");}
 
 S exc(C c){
     static S psb; //string buffer
@@ -309,6 +310,7 @@ S exc(C c){
         px=0;switch(c){
         case '(':sh(st,0);BK;
         case ')':sh(st,1);BK;
+        case '&':psh(st,idx(st));BK;
         default:PE;
     }}
     else if(pv){pv=0;if(v[c])dlo(v[c]);v[c]=dup(top(st));} //save var
@@ -598,7 +600,8 @@ T(aop){TI //test array ops
 }
 
 T(dop){TI //test dict/entry ops
-    TX("'a1t",E,newosz("a"),newod(1))
+    TX("'aAt",E,newosz("a"),newod(10))
+    TX("['aAt]'a!&",D,10)
 }
 
 T(vars){TI //test vars

--- a/o.c
+++ b/o.c
@@ -197,7 +197,7 @@ O rvxs(O o){S r;L z;r=alc(o->s.z+1);for(z=0;z<o->s.z;++z)r[o->s.z-z-1]=o->s.s[z]
 O rvxd(O o){S s=tos(o);R newosk(s,strlen(s));} //int2str
 V rvx(ST s){O r,o=pop(s);r=o->t==TD?rvxd(o):o->t==TS?rvxs(o):0;if(!r)TE;psh(s,r);dlo(o);}  //reverse/int2str
 
-V idc(ST s,C c){O o=pop(s);if(o->t!=TD)TE;psh(s,newod(c=='('?o->d-1:o->d+1));dlo(o);} //inc/dec
+V idc(ST s,C c){O o=pop(s);if(o->t==TR)psh(s,dup(c=='('?o->e.k:o->e.v));else if(o->t==TD)psh(s,newod(c=='('?o->d-1:o->d+1));else TE;dlo(o);} //inc/dec/index entry
 
 V opar(){ST r;O a=pop(top(rst));L i;psh(rst,r=newst(BZ));for(i=0;i<len(a->a);++i)psh(r,dup(a->a->st[i]));dlo(a);} //open array
 
@@ -609,6 +609,8 @@ T(aop){TI //test array ops
 
 T(dop){TI //test dict/entry ops
     TX("A'at",E,newosz("a"),newod(10))
+    TX("A'at(",S,"a")
+    TX("A'at)",D,10)
     TX("[A'at]'a!&",D,10)
     TX("A'at[]=e",D,1)
     TX("A'at[]=&",E,newosz("a"),newod(10))

--- a/o.c
+++ b/o.c
@@ -188,7 +188,7 @@ O divs(O a,O b,ST s){S p,l=a->s.s;if(b->s.z==0){for(p=a->s.s;p<a->s.s+a->s.z;++p
 OTF divfn[TN]={divd,divs,0,0};
 
 V eq(ST s){O a,b;b=pop(s);a=pop(s);
-    if(b->t==TA){I i,w=0;if(a->t!=TR)a=newoe(pop(s),a);for(i=0;i<len(b->a);++i){O e=b->a->st[i];if(e->t!=TR)TE;if(eqo(e->e.k,a->e.k)){dlo(e);b->a->st[i]=a;w=1;BK;}}if(!w)psh(b->a,a);psh(s,b);} //set
+    if(b->t==TA){I i,w=0;if(a->t!=TR)a=newoe(a,pop(s));for(i=0;i<len(b->a);++i){O e=b->a->st[i];if(e->t!=TR)TE;if(eqo(e->e.k,a->e.k)){dlo(e);b->a->st[i]=a;w=1;BK;}}if(!w)psh(b->a,a);psh(s,b);} //set
     else if(a->t!=TA){psh(s,newod(eqo(a,b)));dlo(a);dlo(b);} //equal
     else TE;
 } //equal,dict set
@@ -278,7 +278,7 @@ V uv(ST s,O o){if(o->t==TCB)excb(o);else psh(s,dup(o));} //execute the object if
 
 V bcv(ST s){ST r;I i=0,a,b;O ao,bo=pop(s);ao=pop(s);if(ao->t!=TD||bo->t!=TD)TE;a=ao->d;b=bo->d/*truncate*/;dlo(ao);dlo(bo);r=newst(BZ);while(a){C c=a%b+'0';if(c>'9')c+=7;psh(r,newod(a%b));if(b==1)--a;else a/=b;}psh(s,newoa(r));} //base conversion
 
-V entry(ST s){O k,v=pop(s);k=pop(s);psh(s,newoe(k,v));}
+V entry(ST s){O v,k=pop(s);v=pop(s);psh(s,newoe(k,v));}
 O idx(ST s){O a,k=pop(s);a=pop(s);I i;if(a->t!=TA)TE;for(i=0;i<len(a->a);++i){O e=a->a->st[i];if(e->t!=TR)TE;if(eqo(e->e.k,k)){O v=dup(e->e.v);dlo(a);dlo(k);R v;};}ex("nonexistent key");R 0;}
 
 S exc(C c){
@@ -604,17 +604,17 @@ T(aop){TI //test array ops
 }
 
 T(dop){TI //test dict/entry ops
-    TX("'aAt",E,newosz("a"),newod(10))
-    TX("['aAt]'a!&",D,10)
-    TX("'aAt[]=e",D,1)
-    TX("'aAt[]=&",E,newosz("a"),newod(10))
-    TX("'aAt['aBt]=e",D,1)
-    TX("'aAt['aBt]=&",E,newosz("a"),newod(10))
-    TX("'aA['aBt]=e",D,1)
-    TX("'aA['aBt]=&",E,newosz("a"),newod(10))
-    TX("'aAt['zBt]=e",D,2)
-    TX("'aAt['zBt]=&",E,newosz("a"),newod(10))
-    TX("'aAt['zBt]=&;&",E,newosz("z"),newod(11))
+    TX("A'at",E,newosz("a"),newod(10))
+    TX("[A'at]'a!&",D,10)
+    TX("A'at[]=e",D,1)
+    TX("A'at[]=&",E,newosz("a"),newod(10))
+    TX("A'at[B'at]=e",D,1)
+    TX("A'at[B'at]=&",E,newosz("a"),newod(10))
+    TX("A'a[B'at]=e",D,1)
+    TX("A'a[B'at]=&",E,newosz("a"),newod(10))
+    TX("A'at[B'zt]=e",D,2)
+    TX("A'at[B'zt]=&",E,newosz("a"),newod(10))
+    TX("A'at[B'zt]=&;&",E,newosz("z"),newod(11))
 }
 
 T(vars){TI //test vars


### PR DESCRIPTION
Sorry this took so long!

Basically, this is how I ended up making it work:

- `2'at` creates an entry `{a: 2}`. Note that I had to reverse the key and value; otherwise, it would be impossible to tell this apart from the next form.
- `[2'a]t` creates an array of entries `[{a: 2}]`.
- `[2'a]t 'a !&` looks up `a` in the dictionary, raising an error if the lookup fails.
- `2 'a []t=` results in the dictionary `[{a: 1}]`. Again, note that I had to put the value and key *before* the array, otherwise `=` would fail to know whether or not to do a normal comparison.
- You can also use `=` with an already-created entry: `2 'a t []t=` works the same way as above.
- `(` gets the key from an entry, and `)` gets the value.

@phase Please review!